### PR TITLE
Testing load heavy queries

### DIFF
--- a/src/client/main.go
+++ b/src/client/main.go
@@ -22,6 +22,10 @@ func main() {
 		} else {
 			go simpleGet("/longQ")
 		}
+
+		if rand.Float64() > 0.97 {
+			go simpleGet("/loadQ")
+		}
 	}
 }
 

--- a/src/server/endpoints/loadQuery.go
+++ b/src/server/endpoints/loadQuery.go
@@ -1,0 +1,19 @@
+package endpoints
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+func LoadQuery (w http.ResponseWriter, _ *http.Request) {
+	res := 1
+	for i:=1; i<(1<<20); i++ {
+		for j:=1; j<(1<<30); j++ {
+			res = ((res * (i % 133711)) + j) % 133711
+		}
+	}
+	io.WriteString(w, strconv.Itoa(res))
+	fmt.Println("Received a load heavy query", res)
+}

--- a/src/server/main.go
+++ b/src/server/main.go
@@ -21,6 +21,7 @@ func main() {
 
     router.HandleFunc("/ping", sep.Ping).Methods("GET")
     router.HandleFunc("/longQ", sep.LongQuery).Methods("GET")
+    router.HandleFunc("/loadQ", sep.LoadQuery).Methods("GET")
     router.HandleFunc("/pgQ/{id}", sep.PGQuery).Methods("GET")
     
     handler := cors.Default().Handler(router)


### PR DESCRIPTION
Adding a query that uses a lot of cpu can put a lot of strain on the network. First hypothesis is that using a message queue can optimize resources in handling such queries.