### PR TITLE
Added Haproxy and Keepalived infront of Nginx. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,19 +2,34 @@ version: "3.7"
 
 
 services: 
+    haproxy:
+        image: eisandbar/network:haproxy
+        build:
+            context: ./haproxy/
+            dockerfile: Dockerfile
+        depends_on:
+            - nginx
+        ports:
+            - "5100:5100"
+        networks:
+            external:
+            web-net:       
+        mem_limit: 16m
+        mem_reservation: 16m
+        cpus: 0.125
+        restart: always
+
     nginx:
         image: eisandbar/network:nginx
         build:
             context: ./nginx/
             dockerfile: Dockerfile
+        deploy:
+            replicas: 2
         depends_on:
             - server
-        ports:
-            - "5100:5100"
         networks:
             web-net:
-                aliases:
-                    - api
         mem_limit: 16m
         mem_reservation: 16m
         cpus: 0.125
@@ -50,11 +65,11 @@ services:
         image: eisandbar/network:client
         build: ./src/client
         depends_on:
-            - server
+            - haproxy
         volumes:
             - ./:/app
         networks:
-            - web-net
+            - external
         mem_limit: 32m
         mem_reservation: 16m
         cpus: 0.125
@@ -89,6 +104,9 @@ services:
         cpus: 0.125
 
 networks:
+    external:
+        driver: overlay
+        attachable: true
     web-net:
         driver: overlay
         attachable: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
             context: ./keepalived/ 
             dockerfile: Dockerfile_master
         network_mode: host
+        profiles: ["master"]
         
     haproxy_slave:
         <<: *default-mem2
@@ -60,6 +61,7 @@ services:
             context: ./keepalived/ 
             dockerfile: Dockerfile_slave
         network_mode: host
+        profiles: ["slave"]
 
     nginx:        
         <<: *default-mem2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,68 @@
 version: "3.7"
 
+x-mem: &default-mem
+    mem_limit: 16m
+    mem_reservation: 16m
+    cpus: 0.125
+    restart: always
+
+x-mem2: &default-mem2
+    mem_limit: 64m
+    mem_reservation: 32m
+    cpus: 0.25
+    restart: always
+
+x-haproxy: &haproxy
+    image: eisandbar/network:haproxy
+    build:
+        context: ./haproxy/
+        dockerfile: Dockerfile
+    depends_on:
+        - nginx
+
+x-keepalived: &keepalived
+    image: eisandbar/network:keepalived
+    cap_add:
+        - NET_ADMIN
+        - NET_BROADCAST
+        - NET_RAW
+    depends_on:
+        - haproxy_slave
+        - haproxy_master
 
 services: 
-    haproxy:
-        image: eisandbar/network:haproxy
-        build:
-            context: ./haproxy/
-            dockerfile: Dockerfile
-        depends_on:
-            - nginx
-        ports:
-            - "5100:5100"
+    haproxy_master:
+        <<: *default-mem2
+        <<: *haproxy
         networks:
-            external:
-            web-net:       
-        mem_limit: 16m
-        mem_reservation: 16m
-        cpus: 0.125
-        restart: always
+            web-net:
+                ipv4_address: "172.20.1.20"
 
-    nginx:
+    keepalived_master:
+        <<: *default-mem2
+        <<: *keepalived
+        build:
+            context: ./keepalived/ 
+            dockerfile: Dockerfile_master
+        network_mode: host
+        
+    haproxy_slave:
+        <<: *default-mem2
+        <<: *haproxy
+        networks:
+            web-net:
+                ipv4_address: "172.20.1.30"
+
+    keepalived_slave:
+        <<: *default-mem2
+        <<: *keepalived
+        build:
+            context: ./keepalived/ 
+            dockerfile: Dockerfile_slave
+        network_mode: host
+
+    nginx:        
+        <<: *default-mem2
         image: eisandbar/network:nginx
         build:
             context: ./nginx/
@@ -30,23 +73,13 @@ services:
             - server
         networks:
             web-net:
-        mem_limit: 16m
-        mem_reservation: 16m
-        cpus: 0.125
-        restart: always
     
-    server:
+    server:        
+        <<: *default-mem2
         image: eisandbar/network:server
         build: ./src/server
         deploy:
             replicas: 3
-            resources:
-                limits:
-                    cpus: "0.25"
-                    memory: 64M
-                reservations:
-                    cpus: "0.125"
-                    memory: 32M
         depends_on:
             - db
         volumes:
@@ -59,38 +92,32 @@ services:
             POSTGRES_PASSWORD: secret
             POSTGRES_DB: pgdb
             POSTGRES_HOST: db
-        restart: always
     
     client:
+        # <<: *default-mem
         image: eisandbar/network:client
         build: ./src/client
         depends_on:
-            - haproxy
+            - haproxy_master
+            - haproxy_slave
         volumes:
             - ./:/app
-        networks:
-            - external
-        mem_limit: 32m
-        mem_reservation: 16m
-        cpus: 0.125
-        restart: always
+        network_mode: host
     
     db:
+        # <<: *default-mem2
         image: postgres
         volumes:
             - postgres:/var/lib/postgres
         networks:
             - db-net
-        mem_limit: 64m
-        mem_reservation: 32m
-        cpus: 0.25
-        restart: always
         environment:
             POSTGRES_USER: pguser
             POSTGRES_PASSWORD: secret
             POSTGRES_DB: pgdb
     
     redis:
+        # <<: *default-mem
         image: eisandbar/network:redis
         build:
             context: ./redis/
@@ -99,20 +126,14 @@ services:
             - redis:/data
         networks:
             - db-net
-        mem_limit: 32m
-        mem_reservation: 16m
-        cpus: 0.125
 
 networks:
-    external:
-        driver: overlay
-        attachable: true
     web-net:
-        driver: overlay
-        attachable: true
+        ipam:
+            config:
+                - subnet: 172.20.0.0/16
     db-net:
-        driver: overlay
-        attachable: true
+        driver: bridge
 
 
 volumes:

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,0 +1,2 @@
+FROM haproxy:2.4
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -1,0 +1,20 @@
+global
+    maxconn 10000
+
+defaults
+    log     global
+    mode    tcp
+    option  tcplog
+    timeout connect 10s
+    timeout client  50s
+    timeout server  50s
+
+frontend www
+    bind :5100
+    default_backend nginx
+
+backend nginx
+    balance roundrobin
+    mode tcp
+    server web1 network_nginx_1:5100 check
+    server web2 network_nginx_2:5100 check

--- a/keepalived/Dockerfile_master
+++ b/keepalived/Dockerfile_master
@@ -1,0 +1,5 @@
+FROM osixia/keepalived:2.0.20
+USER root
+COPY keepalived_master.conf /usr/local/etc/keepalived/keepalived.conf
+RUN chmod 644 /usr/local/etc/keepalived/keepalived.conf
+COPY notify.sh /container/service/keepalived/assets/notify.custom.sh

--- a/keepalived/Dockerfile_slave
+++ b/keepalived/Dockerfile_slave
@@ -1,0 +1,5 @@
+FROM osixia/keepalived:2.0.20
+USER root
+COPY keepalived_slave.conf /usr/local/etc/keepalived/keepalived.conf
+RUN chmod 644 /usr/local/etc/keepalived/keepalived.conf
+COPY notify.sh /container/service/keepalived/assets/notify.custom.sh

--- a/keepalived/keepalived_master.conf
+++ b/keepalived/keepalived_master.conf
@@ -1,0 +1,40 @@
+vrrp_script chk_haproxy {
+    script "killall -0 haproxy"   # verify the pid existance
+    interval 2                    # check every 2 seconds
+    weight 2                      # add 2 points of prio if OK
+}
+
+vrrp_instance VI_1 {
+    state MASTER
+    interface eth0                # interface to monitor
+    virtual_router_id 51          # Assign one ID for this route
+    priority 200                  # 200 on master, 100 on backup
+    virtual_ipaddress {
+        192.168.179.210/24             # the virtual IP
+    }
+    track_script {
+        chk_haproxy
+    }
+    notify "/container/service/keepalived/assets/notify.custom.sh"
+}
+
+virtual_server 192.168.179.210 5100 {
+    # delay_loop 5
+    # lb_algo wlc
+    # lb_kind NAT
+    # persistence_timeout 600
+    protocol TCP
+
+    real_server 172.20.1.20 5100 {
+        weight 100
+        TCP_CHECK {
+            connect_timeout 10
+        }
+    }
+    real_server 172.20.1.30 5100 {
+        weight 100
+        TCP_CHECK {
+            connect_timeout 10
+        }
+    }
+}

--- a/keepalived/keepalived_master.conf
+++ b/keepalived/keepalived_master.conf
@@ -1,16 +1,16 @@
 vrrp_script chk_haproxy {
-    script "killall -0 haproxy"   # verify the pid existance
+    script "pidof haproxy"   # verify the pid existance
     interval 2                    # check every 2 seconds
     weight 2                      # add 2 points of prio if OK
 }
 
 vrrp_instance VI_1 {
     state MASTER
-    interface eth0                # interface to monitor
+    interface enp8s0                # interface to monitor
     virtual_router_id 51          # Assign one ID for this route
-    priority 200                  # 200 on master, 100 on backup
+    priority 101                  # 200 on master, 100 on backup
     virtual_ipaddress {
-        192.168.179.210/24             # the virtual IP
+        172.17.20.20/16             # the virtual IP
     }
     track_script {
         chk_haproxy
@@ -18,11 +18,11 @@ vrrp_instance VI_1 {
     notify "/container/service/keepalived/assets/notify.custom.sh"
 }
 
-virtual_server 192.168.179.210 5100 {
-    # delay_loop 5
-    # lb_algo wlc
-    # lb_kind NAT
-    # persistence_timeout 600
+virtual_server 172.17.20.20 5100 {
+    delay_loop 5
+    lb_algo wlc
+    lb_kind NAT
+    persistence_timeout 600
     protocol TCP
 
     real_server 172.20.1.20 5100 {

--- a/keepalived/keepalived_slave.conf
+++ b/keepalived/keepalived_slave.conf
@@ -1,16 +1,16 @@
 vrrp_script chk_haproxy {
-    script "killall -0 haproxy"   # verify the pid existance
+    script "pidof haproxy"   # verify the pid existance
     interval 2                    # check every 2 seconds
     weight 2                      # add 2 points of prio if OK
 }
 
 vrrp_instance VI_1 {
     state BACKUP
-    interface eth0                # interface to monitor
+    interface enp8s0                # interface to monitor
     virtual_router_id 51          # Assign one ID for this route
     priority 100                  # 200 on master, 100 on backup
     virtual_ipaddress {
-        192.168.179.210/24             # the virtual IP
+        172.17.20.20/16             # the virtual IP
     }
     track_script {
         chk_haproxy
@@ -18,11 +18,11 @@ vrrp_instance VI_1 {
     notify "/container/service/keepalived/assets/notify.custom.sh"
 }
 
-virtual_server 192.168.179.210 5100 {
-    # delay_loop 5
-    # lb_algo wlc
-    # lb_kind NAT
-    # persistence_timeout 600
+virtual_server 172.17.20.20 5100 {
+    delay_loop 5
+    lb_algo wlc
+    lb_kind NAT
+    persistence_timeout 600
     protocol TCP
 
     real_server 172.20.1.20 5100 {

--- a/keepalived/keepalived_slave.conf
+++ b/keepalived/keepalived_slave.conf
@@ -1,0 +1,40 @@
+vrrp_script chk_haproxy {
+    script "killall -0 haproxy"   # verify the pid existance
+    interval 2                    # check every 2 seconds
+    weight 2                      # add 2 points of prio if OK
+}
+
+vrrp_instance VI_1 {
+    state BACKUP
+    interface eth0                # interface to monitor
+    virtual_router_id 51          # Assign one ID for this route
+    priority 100                  # 200 on master, 100 on backup
+    virtual_ipaddress {
+        192.168.179.210/24             # the virtual IP
+    }
+    track_script {
+        chk_haproxy
+    }
+    notify "/container/service/keepalived/assets/notify.custom.sh"
+}
+
+virtual_server 192.168.179.210 5100 {
+    # delay_loop 5
+    # lb_algo wlc
+    # lb_kind NAT
+    # persistence_timeout 600
+    protocol TCP
+
+    real_server 172.20.1.20 5100 {
+        weight 100
+        TCP_CHECK {
+            connect_timeout 10
+        }
+    }
+    real_server 172.20.1.30 5100 {
+        weight 100
+        TCP_CHECK {
+            connect_timeout 10
+        }
+    }
+}

--- a/keepalived/notify.sh
+++ b/keepalived/notify.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# for ANY state transition.
+# "notify" script is called AFTER the
+# notify_* script(s) and is executed
+# with 3 arguments provided by keepalived
+# (ie don't include parameters in the notify line).
+# arguments
+# $1 = "GROUP"|"INSTANCE"
+# $2 = name of group or instance
+# $3 = target state of transition
+#     ("MASTER"|"BACKUP"|"FAULT")
+
+TYPE=$1
+NAME=$2
+STATE=$3
+
+case $STATE in
+    "MASTER") echo "[$1 - $2] I'm the MASTER! Whup whup." > /proc/1/fd/1
+        exit 0
+    ;;
+    "BACKUP") echo "[$1 - $2] Ok, i'm just a backup, great." > /proc/1/fd/1
+        exit 0
+    ;;
+    "FAULT")  echo "[$1 - $2] Fault, what ?" > /proc/1/fd/1
+        exit 0
+    ;;
+    *)        echo "[$1 - $2] Unknown state" > /proc/1/fd/1
+        exit 1
+    ;;
+esac

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,8 +18,10 @@ http {
 
         # Proxying the connections
         location / {
-            proxy_pass         http://api_servers;
-            proxy_read_timeout 10m;
+            resolver            127.0.0.11 valid=30s;
+            set $servers        api_servers;
+            proxy_pass          http://$servers;
+            proxy_read_timeout  10m;
         }
     }
 }

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -1,2 +1,2 @@
-maxmemory 32mb
+maxmemory 16mb
 maxmemory-policy allkeys-lru

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -12,7 +12,10 @@ import (
 )
 
 func main() {
-	for {
+	for true {
+		
+	}
+	for false {
 		time.Sleep(200 * time.Millisecond)
 
 		// Simple queries

--- a/src/client/util/conn.go
+++ b/src/client/util/conn.go
@@ -1,7 +1,7 @@
 package conn
 
 const (
-	CONN_HOST = "api"
+	CONN_HOST = "network_haproxy_1"
 	CONN_PORT = "5100"
 )
 


### PR DESCRIPTION
Adding keepalived infront of haproxy so that we can have 2  servers. All requests are to the VIP, and if the master server fails, requests will be redirected to the backup

Keepalived is for linux only, testing on single machine can be difficult

Using x-profiles for redundant code in docker compose
Using profiles so that it is easier to control what containers we run